### PR TITLE
Update bluemix-simple-http-client-swift to 0.8.x

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,6 +16,6 @@ import PackageDescription
 let package = Package(
     name: "BluemixObjectStorage",
 	dependencies: [
-		.Package(url: "https://github.com/ibm-bluemix-mobile-services/bluemix-simple-http-client-swift.git", majorVersion: 0, minor: 7)
+		.Package(url: "https://github.com/ibm-bluemix-mobile-services/bluemix-simple-http-client-swift.git", majorVersion: 0, minor: 8)
 	]
 )


### PR DESCRIPTION
Provides compatibility with Kitura 2.x and Kitura-net 2.x for users on Swift 4 (Swift 3 should continue to work as before with Kitura 1 / Kitura-net 1)